### PR TITLE
Tweaks

### DIFF
--- a/erc-tweet.el
+++ b/erc-tweet.el
@@ -66,6 +66,8 @@
     (backward-char)
     (buffer-substring-no-properties pt-before (point))))
 
+(defvar erc-tweet-cleanup-text 'erc-strip-tags)
+
 (defun erc-tweet (status marker)
   (interactive)
   (let ((tweet-text (erc-tweet-text)))
@@ -75,7 +77,7 @@
           (goto-char (marker-position marker))
           (let ((pt-before (point)))
             (insert-before-markers
-             (erc-strip-tags (concat "[tweet] - " tweet-text)))
+             "[tweet] - " (funcall erc-tweet-cleanup-text tweet-text))
             (put-text-property pt-before (point) 'read-only t)))))))
 
 (defun erc-tweet-correct-url (url)


### PR DESCRIPTION
I just realized I had made several handy tweaks to erc-tweet without
offering them back.  Sorry for the less than descriptive PR title.  :)

The changes are pretty self-contained commit-to-commit and I'd be
happy to split them into separate PRs if you'd rather have some but
not others.

The main changes are:
1. Mark only the new tweet text as read only.  I kept running into the
   case where I'd be typing a message and a tweet would come through
   and my unsent text would also be marked as read-only.
2. Handle mobile twitter URLs by removing the "mobile." from the
   beginning of the url before fetching the tweet.
3. Make the function that cleans up the tweet-text pluggable.  By
   default it stays as `erc-strip-tags` but this allows me to use w3m
   to render the tweets thereby rendering entities and such.  See the 
   commit message on e735d01 for that code- I didn't know if you'd want 
   it in erc-tweet directly, so I left it there.

Thanks!
