### PR TITLE
Tweet text with non-unibyte characters are properly encoded and inserted...

### DIFF
--- a/erc-tweet.el
+++ b/erc-tweet.el
@@ -64,7 +64,7 @@
 
 ")
     (backward-char)
-    (buffer-substring-no-properties pt-before (point))))
+    (string-as-multibyte (buffer-substring-no-properties pt-before (point)))))
 
 (defvar erc-tweet-cleanup-text 'erc-tweet-strip-tags)
 


### PR DESCRIPTION
As with the fix for erc-youtube.el, Emacs 24.3 url-retrieve<f> and friends returns the network data in a unibyte buffer. We force a multibyte interpretation, and coupled with utf-8 encoding settings, fixes the problem.

Signed-off-by: piyo piyo@users.sf.net

Tested with (string= current-language-environment "UTF-8") Emacs 24.3.
Sorry no tests because I couldn't pick anything neutral.
